### PR TITLE
Further testing of the no parse template feature

### DIFF
--- a/test/includes.js
+++ b/test/includes.js
@@ -39,6 +39,16 @@ describe('Includes', function () {
     done()
   })
 
+  it('should <include> a template as an argument but not parse any teddy features (includes/includeNoTeddyFeatureAsArgument.html)', function (done) {
+    assert.equalIgnoreSpaces(teddy.render('includes/includeNoTeddyFeature1.html', model), '{!should remove {! server side comments !}!}<p>test {! this should be removed !} test</p>')
+    done()
+  })
+
+  it('should <include> a template as an argument but not parse any teddy features (includes/includeNoParsingFeatureAsArgument.html)', function (done) {
+    assert.equalIgnoreSpaces(teddy.render('includes/includeNoParsingFeatureAsArgument.html', model), '{!should remove {! server side comments !}!}<p>test {! this should be removed !} test</p>')
+    done()
+  })
+
   it('should <include> a template whose name is populated by a {variable} (includes/dynamicInclude.html)', function (done) {
     assert.equalIgnoreSpaces(teddy.render('includes/dynamicInclude.html', model), '<p>Some content</p>')
     done()

--- a/test/templates/includes/includeNoParsingFeatureAsArgument.html
+++ b/test/templates/includes/includeNoParsingFeatureAsArgument.html
@@ -1,0 +1,10 @@
+{!
+  should <include> a template but not parse features
+!}
+
+<include src='misc/markupArgument'>
+  <arg something>
+    <include src='misc/serverSideComments' noparse></include>
+  </arg>
+</include>
+

--- a/test/templates/includes/includeNoTeddyFeatureAsArgument.html
+++ b/test/templates/includes/includeNoTeddyFeatureAsArgument.html
@@ -1,0 +1,10 @@
+{!
+  should <include> a template but not parse features
+!}
+
+<include src='misc/markupArgument'>
+  <arg something>
+    <include src='misc/serverSideComments' noteddy></include>
+  </arg>
+</include>
+


### PR DESCRIPTION
I added two new tests which demonstrate the no parsing functionality breaking. It seems to break when the template is passed as an argument.